### PR TITLE
Fix crouton install directory and external exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A little extra help for using [Crouton](https://github.com/dnschneid/crouton), t
 ## Bootstrapping
 * download and unpack [the zip file](https://github.com/qrkourier/crouton-crucial/archive/master.zip)
 * edit crucial.rc to configure a new or existing chroot
+* move files to excutable path (best to store with crouton excutabale in `/usr/local/bin`)
 * press ctrl-alt-t to open a crosh terminal
 * invoke bash as root (requires Chromebook Developer Mode)
 ```

--- a/crucial.rc
+++ b/crucial.rc
@@ -54,3 +54,5 @@ CRSTARTCMD=startxfce4
 # installation dir
 CRINSTALLER="https://raw.githubusercontent.com/dnschneid/crouton/master/installer/crouton"
 
+#Working Dir change
+THISWORKINGDIR="/usr/local/bin"

--- a/crucial.sh
+++ b/crucial.sh
@@ -197,6 +197,8 @@ fi
 
 # enter
 STARTUPOPTS="-c $CRPATH/chroots -n ${CRNAME:?} $CRRUNCMD"
+echo "Changing $CRPATH to exec"
+mount -o remount,exec,symfollow $CRPATH
 if [[ -n "$KEEPAWAKE" ]];then
   export CRPATH
   exec /bin/sh $THISWORKINGDIR/keepawake.sh $STARTUPOPTS


### PR DESCRIPTION
Due to new chromeos restrictions, many paths now cannot run executables.
Use new recommended crouton install directory `/usr/local/bin` by default
Users can set another path in rc file, but that path must have exec permission.

Also, script will now auto remount chroot path with `exec` and `symfollow`
This will fix launching chroot in external media (i.e. SD card)